### PR TITLE
fix: Rescue on EOf error and retry

### DIFF
--- a/lib/heroku_log_streamer.rb
+++ b/lib/heroku_log_streamer.rb
@@ -32,6 +32,9 @@ class HerokuLogStreamer
     rescue Errno::ECONNREFUSED
       MonitorLogger.error 'Failed to connect to Heroku logplex. Retrying'
       retry
+    rescue EOFError
+      MonitorLogger.error 'End of file (EOF) reached. Retrying'
+      retry
     end
   end
 

--- a/spec/heroku_log_streamer_spec.rb
+++ b/spec/heroku_log_streamer_spec.rb
@@ -37,6 +37,7 @@ describe HerokuLogStreamer do
     pending 'should yield with log line'
     pending 'should retry on timeout error'
     pending 'should retry on connection error'
+    pending 'should retry on end of file error'
   end
 
   private


### PR DESCRIPTION
Fixed #1 

Rescues on an EOFError and retries.

Adds pending EOF error spec to heroku_log_streamer spec.